### PR TITLE
도메인 설계

### DIFF
--- a/src/main/java/com/fc/boardadmin/converter/RoleTypesConverter.java
+++ b/src/main/java/com/fc/boardadmin/converter/RoleTypesConverter.java
@@ -1,0 +1,27 @@
+package com.fc.boardadmin.converter;
+
+import com.fc.boardadmin.domain.constant.RoleType;
+
+import javax.management.relation.Role;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter
+public class RoleTypesConverter implements AttributeConverter<Set<RoleType>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<RoleType> attribute) {
+        return attribute.stream().map(RoleType::name).sorted().collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<RoleType> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(DELIMITER)).map(RoleType::valueOf).collect(Collectors.toSet());
+    }
+
+}

--- a/src/main/java/com/fc/boardadmin/domain/AuditingFields.java
+++ b/src/main/java/com/fc/boardadmin/domain/AuditingFields.java
@@ -1,0 +1,41 @@
+package com.fc.boardadmin.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    // 메타데이터는 자동 세팅되므로 Setter 를 사용하지 않음.
+    /** 생성일시 */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+    /** 생성자 */
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    protected String createdBy;
+    /** 수정일시 */
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+    /** 수정자 */
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    protected String modifiedBy;
+}

--- a/src/main/java/com/fc/boardadmin/domain/UserAccount.java
+++ b/src/main/java/com/fc/boardadmin/domain/UserAccount.java
@@ -1,0 +1,83 @@
+package com.fc.boardadmin.domain;
+
+import com.fc.boardadmin.converter.RoleTypesConverter;
+import com.fc.boardadmin.domain.constant.RoleType;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class UserAccount extends AuditingFields {
+    @Id
+    @Setter
+    @Column(nullable = false, length = 50)
+    private String userId;
+
+    @Setter @Column(nullable = false) private String userPassword;
+    /** join 1:1 테이블 만들지 않고 */
+    @Convert(converter = RoleTypesConverter.class)
+    @Setter @Column(nullable = false) private Set<RoleType> roleTypes = new LinkedHashSet<>(); // 1,2,3 -> table_column
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes,String email, String nickname, String memo, String createdBy) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.roleTypes = roleTypes;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+        this.createdBy = createdBy;
+        this.modifiedBy = createdBy;
+    }
+
+    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    }
+
+    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    }
+
+    public void addRoleType(RoleType roleType) {
+        this.getRoleTypes().add(roleType);
+    }
+
+    public void addRoleTypes(Collection<RoleType> roleTypes) {
+        this.getRoleTypes().addAll(roleTypes);
+    }
+
+    public void removeRoleType(RoleType roleType) {
+        this.getRoleTypes().remove(roleType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
+    }
+
+}

--- a/src/main/java/com/fc/boardadmin/domain/constant/RoleType.java
+++ b/src/main/java/com/fc/boardadmin/domain/constant/RoleType.java
@@ -1,0 +1,16 @@
+package com.fc.boardadmin.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RoleType {
+    USER("ROLE_USER"),
+    MANAGER("ROLE_MANAGER"),
+    DEVELOPER("ROLE_DEVELOPER"),
+    ADMIN("ROLE_ADMIN"),
+    ;
+
+    @Getter
+    private final String roleName;
+}

--- a/src/main/java/com/fc/boardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fc/boardadmin/dto/UserAccountDto.java
@@ -1,0 +1,55 @@
+package com.fc.boardadmin.dto;
+
+import com.fc.boardadmin.domain.UserAccount;
+import com.fc.boardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record UserAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static UserAccountDto from(UserAccount entity) {
+        return new UserAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public UserAccount toEntity() {
+        return UserAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/fc/boardadmin/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fc/boardadmin/security/BoardAdminPrincipal.java
@@ -1,0 +1,118 @@
+package com.fc.boardadmin.security;
+
+import com.fc.boardadmin.domain.constant.RoleType;
+import com.fc.boardadmin.dto.UserAccountDto;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardAdminPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo,
+        Map<String, Object> oAuth2Attributes
+) implements UserDetails, OAuth2User {
+
+    public static BoardAdminPrincipal of(String username,
+                                         String password,
+                                         Set<RoleType> roleTypes,
+                                         String email,
+                                         String nickname,
+                                         String memo) {
+        return BoardAdminPrincipal.of(username, password, roleTypes, email, nickname, memo, Map.of());
+    }
+
+    public static BoardAdminPrincipal of(String username,
+                                         String password,
+                                         Set<RoleType> roleTypes,
+                                         String email,
+                                         String nickname,
+                                         String memo,
+                                         Map<String, Object> oAuth2Attributes) {
+
+        return new BoardAdminPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getRoleName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo,
+                oAuth2Attributes);
+    }
+
+    public static BoardAdminPrincipal from(UserAccountDto dto) {
+        return BoardAdminPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.roleTypes(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo());
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(username, password, roleTypes, email, nickname, memo);
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2Attributes;
+    }
+
+    // 유저 권한
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    // Spring Security 에 의존
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return username;
+    }
+
+
+}

--- a/src/main/java/com/fc/boardadmin/security/KakaoOAuth2Response.java
+++ b/src/main/java/com/fc/boardadmin/security/KakaoOAuth2Response.java
@@ -1,0 +1,59 @@
+package com.fc.boardadmin.security;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@SuppressWarnings("unchecked") // TODO: Map -> Object 변환 로직이 있어 제네릭 타입 캐스팅 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
+public record KakaoOAuth2Response(
+        Long id,
+        LocalDateTime connectedAt,
+        Map<String, Object> properties,
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            Boolean profileNicknameNeedsAgreement,
+            Profile profile,
+            Boolean hasEmail,
+            Boolean emailNeedsAgreement,
+            Boolean isEmailValid,
+            Boolean isEmailVerified,
+            String email
+    ) {
+        public record Profile(String nickname) {
+            public static Profile from(Map<String, Object> attributes) {
+                return new Profile(String.valueOf(attributes.get("nickname")));
+            }
+        }
+
+        public static KakaoAccount from(Map<String, Object> attributes) {
+            return new KakaoAccount(
+                    Boolean.valueOf(String.valueOf(attributes.get("profile_nickname_needs_agreement"))),
+                    Profile.from((Map<String, Object>) attributes.get("profile")),
+                    Boolean.valueOf(String.valueOf(attributes.get("has_email"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("email_needs_agreement"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_valid"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_verified"))),
+                    String.valueOf(attributes.get("email"))
+            );
+        }
+
+        public String nickname() { return this.profile().nickname(); }
+    }
+
+    public static KakaoOAuth2Response from(Map<String, Object> attributes) {
+        return new KakaoOAuth2Response(
+                Long.valueOf(String.valueOf(attributes.get("id"))),
+                LocalDateTime.parse(
+                        String.valueOf(attributes.get("connected_at")),
+                        DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault())
+                ),
+                (Map<String, Object>) attributes.get("properties"),
+                KakaoAccount.from((Map<String, Object>) attributes.get("kakao_account"))
+        );
+    }
+
+    public String email() { return this.kakaoAccount().email(); }
+    public String nickname() { return this.kakaoAccount().nickname(); }
+}


### PR DESCRIPTION
회원 엔티티, 권한 엔티티회원 체계는 반드시 들어갈 것으로 예상하므로
도메인 설계를 함

권한 체계가 새로 들어갔고, 권한을 db 컬럼에 작성할 때
하나의 회원에 여러 권한을 주기 위해
권한 테이블을 새로 만드는 방법이 부담스럽다.
그리고 게시판 프로젝트에서 이미 잘 연습했으므로,
색다른 방법으로 구현을 접근함

권한 정보를 합쳐진 문자열로 저장하게끔 하고,
이를 컨버터로 구현함

새로운 권한 체계는 `RoleType` enum 으로 소개함